### PR TITLE
[xtf utils] Bump xtf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <log4j.over.slf4j.version>1.7.25</log4j.over.slf4j.version>
         <lombok.version>1.16.18</lombok.version>
         <logback.classic.version>1.2.3</logback.classic.version>
-        <xtf.utilities.version>0.13-SNAPSHOT</xtf.utilities.version>
+        <xtf.utilities.version>0.14</xtf.utilities.version>
         <assertj.version>3.11.1</assertj.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <selenide.version>4.14.2</selenide.version>


### PR DESCRIPTION
The `apicurio-deploy-test-jar` job fails every time because of a missing dependency