### PR TITLE
[ImageStream] Update image stream with specified ui image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <apache.http.commons.version>4.5.3</apache.http.commons.version>
         <guava.version>23.0</guava.version>
         <openshift.client.version>4.3.0</openshift.client.version>
+        <org.json.version>20190722</org.json.version>
 
         <!-- leave driver versions empty to use latest driver -->
         <!-- Find supported webdriver version for your chrome browser here:
@@ -120,6 +121,12 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
             <version>${openshift.client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${org.json.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/test/java/apicurito/tests/TestRunner.java
+++ b/src/test/java/apicurito/tests/TestRunner.java
@@ -40,7 +40,8 @@ public class TestRunner {
 
         if (Boolean.valueOf(TestConfiguration.doReinstall()) && "apicurito".equals(TestConfiguration.openShiftNamespace())) {
             ApicuritoTemplate.cleanNamespace();
-            ApicuritoTemplate.setInputStreams();
+            ApicuritoTemplate.setImageStreams();
+            ApicuritoTemplate.createPullSecret();
             ApicuritoTemplate.deploy();
             if (TestConfiguration.useOperator()) {
                 ApicuritoTemplate.waitForApicurito("apicurito_cr", 3, Component.SERVICE);
@@ -61,7 +62,7 @@ public class TestRunner {
     @AfterClass
     public static void afterTests() {
         log.info("After Tests");
-        if("operatorhub".equals(TestConfiguration.openShiftNamespace())){
+        if ("operatorhub".equals(TestConfiguration.openShiftNamespace())) {
             ApicuritoTemplate.cleanOcpAfterOperatorhubTest();
         }
         if (TestConfiguration.namespaceCleanupAfter()) {

--- a/src/test/java/apicurito/tests/configuration/TestConfiguration.java
+++ b/src/test/java/apicurito/tests/configuration/TestConfiguration.java
@@ -12,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TestConfiguration {
 
+    public static final double APICURITO_IMAGE_VERSION = 2.0;
+
     public static final String OPENSHIFT_URL = "apicurito.config.openshift.url";
     public static final String OPENSHIFT_TOKEN = "apicurito.config.openshift.token";
     public static final String OPENSHIFT_NAMESPACE = "apicurito.config.openshift.namespace";
@@ -35,7 +37,8 @@ public class TestConfiguration {
     public static final String APICURITO_OPERATOR_ROLE_URL = "apicurito.config.operator.role";
     public static final String APICURITO_OPERATOR_ROLE_BINDING_URL = "apicurito.config.operator.rolebinding";
     public static final String APICURITO_OPERATOR_CR_URL = "apicurito.config.operator.cr";
-    public static final String APICURITO_OPERATOR_UI_IMAGE = "apicurito.config.ui.image";
+    public static final String APICURITO_UI_IMAGE = "apicurito.config.ui.image";
+    public static final String APICURITO_PULL_SECRET = "apicurito.config.pull.secret";
 
     public static final String APICURITO_UI_USERNAME = "apicurito.config.ui.username";
     public static final String APICURITO_UI_PASSWORD = "apicurito.config.ui.password";
@@ -119,8 +122,8 @@ public class TestConfiguration {
         return get().readValue(APICURITO_OPERATOR_ROLE_BINDING_URL);
     }
 
-    public static String apicuritoOperatorUiImage() {
-        return get().readValue(APICURITO_OPERATOR_UI_IMAGE);
+    public static String apicuritoUiImage() {
+        return get().readValue(APICURITO_UI_IMAGE);
     }
 
     public static int getConfigTimeout() {
@@ -145,6 +148,10 @@ public class TestConfiguration {
 
     public static String getAppRoot() {
         return get().readValue(APP_ROOT, "app-root");
+    }
+
+    public static String apicuritoPullSecret() {
+        return get().readValue(APICURITO_PULL_SECRET);
     }
 
     private Properties defaultValues() {


### PR DESCRIPTION
In this commit:
 - when apicurito ui image is set, override the correct image tag in default image stream
 - new configuration property `apicurito.config.pull.secret` to set pull secret for authentication in a container registry
 - hardcoded image version - when apicurito ui image is set, template will automatically be updated to use provided image with the hardcoded image version