### PR TITLE
[ImageStream] Update image stream with specified ui image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <apache.http.commons.version>4.5.3</apache.http.commons.version>
         <guava.version>23.0</guava.version>
         <openshift.client.version>4.7.1</openshift.client.version>
+        <org.json.version>20190722</org.json.version>
 
         <!-- leave driver versions empty to use latest driver -->
         <!-- Find supported webdriver version for your chrome browser here:
@@ -121,6 +122,12 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
             <version>${openshift.client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${org.json.version}</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/apicurito/tests/TestRunner.java
+++ b/src/test/java/apicurito/tests/TestRunner.java
@@ -26,21 +26,32 @@ public class TestRunner {
     @BeforeClass
     public static void beforeTests() {
 
+        boolean createdProject = false;
+
         if (OpenShiftUtils.xtf().getProject(TestConfiguration.openShiftNamespace()) == null) {
+            createdProject = true;
             log.info("Creating new project " + TestConfiguration.openShiftNamespace());
-            final String output = OpenShiftUtils.binary().execute(
-                    "new-project", TestConfiguration.openShiftNamespace()
-            );
-            try {
-                Thread.sleep(10 * 1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+            OpenShiftUtils.getInstance().createProjectRequest(TestConfiguration.openShiftNamespace());
+            if (OpenShiftUtils.getInstance().getProject() == null) {
+                log.info("Waiting for " + TestConfiguration.openShiftNamespace() + " to be created");
+                try {
+                    Thread.sleep(10 * 1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                log.info(TestConfiguration.openShiftNamespace() + " project created");
             }
         }
 
-        if (Boolean.valueOf(TestConfiguration.doReinstall()) && "apicurito".equals(TestConfiguration.openShiftNamespace())) {
+        if (Boolean.valueOf(TestConfiguration.doReinstall()) && !createdProject) {
             ApicuritoTemplate.cleanNamespace();
-            ApicuritoTemplate.setInputStreams();
+        }
+
+        // TODO: don't rely on namespace name, rather use properties file/maven argument
+        if ("apicurito".equals(TestConfiguration.openShiftNamespace())) {
+            ApicuritoTemplate.createPullSecret();
+            ApicuritoTemplate.setImageStreams();
             ApicuritoTemplate.deploy();
             if (TestConfiguration.useOperator()) {
                 ApicuritoTemplate.waitForApicurito("component", 6, Component.SERVICE);

--- a/src/test/java/apicurito/tests/configuration/TestConfiguration.java
+++ b/src/test/java/apicurito/tests/configuration/TestConfiguration.java
@@ -12,6 +12,8 @@ import java.util.Properties;
 @Slf4j
 public class TestConfiguration {
 
+    public static final String APICURITO_IMAGE_VERSION = "2.0";
+
     public static final String OPENSHIFT_URL = "apicurito.config.openshift.url";
     public static final String OPENSHIFT_TOKEN = "apicurito.config.openshift.token";
     public static final String OPENSHIFT_NAMESPACE = "apicurito.config.openshift.namespace";
@@ -28,14 +30,16 @@ public class TestConfiguration {
 
     public static final String APP_ROOT = "apicurito.config.app.root";
 
-    public static final String APICURITO_TEMPLATE_USE_OPERATOR = "apicurito.config.template.use.operator";
+    public static final String APICURITO_USE_OPERATOR = "apicurito.config.use.operator";
     public static final String APICURITO_OPERATOR_CRD_URL = "apicurito.config.operator.crd";
-    public static final String APICURITO_OPERATOR_URL = "apicurito.config.operator.url";
+    public static final String APICURITO_OPERATOR_DEPLOYMENT_URL = "apicurito.config.operator.deployment.url";
+    public static final String APICURITO_OPERATOR_IMAGE_URL = "apicurito.config.operator.image.url";
     public static final String APICURITO_OPERATOR_SERVICE_URL = "apicurito.config.operator.service";
     public static final String APICURITO_OPERATOR_ROLE_URL = "apicurito.config.operator.role";
     public static final String APICURITO_OPERATOR_ROLE_BINDING_URL = "apicurito.config.operator.rolebinding";
     public static final String APICURITO_OPERATOR_CR_URL = "apicurito.config.operator.cr";
-    public static final String APICURITO_OPERATOR_UI_IMAGE = "apicurito.config.ui.image";
+    public static final String APICURITO_UI_IMAGE = "apicurito.config.ui.image";
+    public static final String APICURITO_PULL_SECRET = "apicurito.config.pull.secret";
     public static final String APICURITO_DEPLOY_OPERATORHUB = "apicurito.config.deploy.operatorhub";
 
     public static final String APICURITO_UI_USERNAME = "apicurito.config.ui.username";
@@ -101,13 +105,14 @@ public class TestConfiguration {
     }
 
     public static boolean useOperator() {
-        return Boolean.parseBoolean(get().readValue(APICURITO_TEMPLATE_USE_OPERATOR));
+        return Boolean.parseBoolean(get().readValue(APICURITO_USE_OPERATOR));
     }
 
     public static boolean deployOperatorHub() {
         return Boolean.parseBoolean(get().readValue(APICURITO_DEPLOY_OPERATORHUB, "false"));
     }
 
+    // pull secret for quay (not for pulling images)
     public static String getPullSecret() {
         return get().readValue(PULL_SECRET);
     }
@@ -120,8 +125,12 @@ public class TestConfiguration {
         return get().readValue(APICURITO_OPERATOR_CR_URL);
     }
 
-    public static String apicuritoOperatorUrl() {
-        return get().readValue(APICURITO_OPERATOR_URL);
+    public static String apicuritoOperatorDeploymentUrl() {
+        return get().readValue(APICURITO_OPERATOR_DEPLOYMENT_URL);
+    }
+
+    public static String apicuritoOperatorImageUrl() {
+        return get().readValue(APICURITO_OPERATOR_IMAGE_URL);
     }
 
     public static String apicuritoOperatorServiceUrl() {
@@ -136,8 +145,8 @@ public class TestConfiguration {
         return get().readValue(APICURITO_OPERATOR_ROLE_BINDING_URL);
     }
 
-    public static String apicuritoOperatorUiImage() {
-        return get().readValue(APICURITO_OPERATOR_UI_IMAGE);
+    public static String apicuritoUiImage() {
+        return get().readValue(APICURITO_UI_IMAGE);
     }
 
     public static int getConfigTimeout() {
@@ -194,6 +203,10 @@ public class TestConfiguration {
         return get().readValue(APICURITO_UI_PASSWORD);
     }
 
+    // pull secret for pulling images
+    public static String apicuritoPullSecret() {
+        return get().readValue(APICURITO_PULL_SECRET);
+    }
 
     private Properties defaultValues() {
         final Properties props = new Properties();
@@ -205,9 +218,9 @@ public class TestConfiguration {
             props.setProperty(APICURITO_OPERATOR_CRD_URL, String.format(
                     "https://raw.githubusercontent.com/Apicurio/apicurio-operators/master/apicurito/deploy/crds/apicur_v1alpha1_apicurito_crd.yaml"));
         }
-        if (props.getProperty(APICURITO_OPERATOR_URL) == null) {
-            props.setProperty(APICURITO_OPERATOR_URL,
-                    String.format("https://raw.githubusercontent.com/Apicurio/apicurio-operators/master/apicurito/deploy/operator.yaml"));
+        if (props.getProperty(APICURITO_OPERATOR_DEPLOYMENT_URL) == null) {
+            props.setProperty(APICURITO_OPERATOR_DEPLOYMENT_URL,
+                String.format("https://raw.githubusercontent.com/Apicurio/apicurio-operators/master/apicurito/deploy/operator.yaml"));
         }
         if (props.getProperty(APICURITO_OPERATOR_CR_URL) == null) {
             props.setProperty(APICURITO_OPERATOR_CR_URL, String.format(
@@ -226,7 +239,7 @@ public class TestConfiguration {
                     String.format("https://raw.githubusercontent.com/Apicurio/apicurio-operators/master/apicurito/deploy/role_binding.yaml"));
         }
 
-        props.setProperty(APICURITO_TEMPLATE_USE_OPERATOR, "true");
+        props.setProperty(APICURITO_USE_OPERATOR, "true");
 
         // Copy syndesis properties to their xtf counterparts - used by binary oc client
         if (System.getProperty("xtf.openshift.url") == null) {

--- a/src/test/java/apicurito/tests/utils/openshift/OpenShiftUtils.java
+++ b/src/test/java/apicurito/tests/utils/openshift/OpenShiftUtils.java
@@ -52,10 +52,12 @@ public final class OpenShiftUtils {
     private OpenShiftUtils() {
         if (xtfUtils == null) {
             final OpenShiftConfigBuilder openShiftConfigBuilder = new OpenShiftConfigBuilder()
-                    .withMasterUrl(TestConfiguration.openShiftUrl())
-                    .withTrustCerts(true)
-                    .withRequestTimeout(120_000)
-                    .withNamespace(TestConfiguration.openShiftNamespace());
+                .withMasterUrl(TestConfiguration.openShiftUrl())
+                .withTrustCerts(true)
+                .withRequestTimeout(120_000)
+                .withNamespace(TestConfiguration.openShiftNamespace())
+                .withUsername(TestConfiguration.getOpenshiftUsername())
+                .withPassword(TestConfiguration.getOpenshiftPassword());
             if (!TestConfiguration.openShiftToken().isEmpty()) {
                 //if token is provided, lets use it
                 //otherwise f8 client should be able to leverage ~/.kube/config or mounted secrets
@@ -67,10 +69,12 @@ public final class OpenShiftUtils {
 
     public static OpenShift getAnotherOpenShiftUtils(String namespace) {
         final OpenShiftConfigBuilder openShiftConfigBuilder = new OpenShiftConfigBuilder()
-                .withMasterUrl(TestConfiguration.openShiftUrl())
-                .withTrustCerts(true)
-                .withRequestTimeout(120_000)
-                .withNamespace(namespace);
+            .withMasterUrl(TestConfiguration.openShiftUrl())
+            .withTrustCerts(true)
+            .withRequestTimeout(120_000)
+            .withNamespace(namespace)
+            .withUsername(TestConfiguration.getOpenshiftUsername())
+            .withPassword(TestConfiguration.getOpenshiftPassword());
         if (!TestConfiguration.openShiftToken().isEmpty()) {
             //if token is provided, lets use it
             //otherwise f8 client should be able to leverage ~/.kube/config or mounted secrets
@@ -101,10 +105,10 @@ public final class OpenShiftUtils {
 
     public static Optional<Pod> getPodByPartialName(String partialName) {
         Optional<Pod> oPod = OpenShiftUtils.getInstance().getPods().stream()
-                .filter(p -> p.getMetadata().getName().contains(partialName))
-                .filter(p -> !p.getMetadata().getName().contains("deploy"))
-                .filter(p -> !p.getMetadata().getName().contains("build"))
-                .findFirst();
+            .filter(p -> p.getMetadata().getName().contains(partialName))
+            .filter(p -> !p.getMetadata().getName().contains("deploy"))
+            .filter(p -> !p.getMetadata().getName().contains("build"))
+            .findFirst();
         return oPod;
     }
 
@@ -120,13 +124,13 @@ public final class OpenShiftUtils {
 
     public static String getPodLogs(String podPartialName) {
         Optional<Pod> integrationPod = OpenShiftUtils.getInstance().getPods().stream()
-                .filter(p -> !p.getMetadata().getName().contains("build"))
-                .filter(p -> !p.getMetadata().getName().contains("deploy"))
-                .filter(p -> p.getMetadata().getName().contains(podPartialName)).findFirst();
+            .filter(p -> !p.getMetadata().getName().contains("build"))
+            .filter(p -> !p.getMetadata().getName().contains("deploy"))
+            .filter(p -> p.getMetadata().getName().contains(podPartialName)).findFirst();
         if (integrationPod.isPresent()) {
             String logText = OpenShiftUtils.getInstance().getPodLog(integrationPod.get());
             assertThat(logText)
-                    .isNotEmpty();
+                .isNotEmpty();
             return logText;
         } else {
             fail("No pod found for pod name: " + podPartialName);
@@ -139,23 +143,23 @@ public final class OpenShiftUtils {
      * Some of the resources can't be created by f8 client, therefore we manually post them to corresponding endpoint.
      *
      * @param kind kind of the resource
-     * @param o    object instance
+     * @param o object instance
      */
     public static void create(String kind, Object o) {
         try {
             final String content = Serialization.jsonMapper().writeValueAsString(o);
             StringBuilder url = new StringBuilder();
-            String[] kinds = new String[]{"serviceaccount", "role", "rolebinding", "clusterrole", "clusterrolebinding", "deployment"};
+            String[] kinds = new String[] {"serviceaccount", "role", "rolebinding", "clusterrole", "clusterrolebinding", "deployment"};
             if (StringUtils.equalsAnyIgnoreCase(kind, kinds)) {
                 url.append("/api")
-                        .append(kind.toLowerCase().equals("serviceaccount") ? "" : "s")
-                        .append("/")
-                        .append(((HasMetadata) o).getApiVersion())
-                        .append("/namespaces/")
-                        .append(TestConfiguration.openShiftNamespace())
-                        .append("/")
-                        .append(kind.toLowerCase())
-                        .append("s");
+                    .append(kind.toLowerCase().equals("serviceaccount") ? "" : "s")
+                    .append("/")
+                    .append(((HasMetadata) o).getApiVersion())
+                    .append("/namespaces/")
+                    .append(TestConfiguration.openShiftNamespace())
+                    .append("/")
+                    .append(kind.toLowerCase())
+                    .append("s");
             } else {
                 // This can be created by the client, so create it
                 getInstance().createResources((HasMetadata) o);
@@ -177,7 +181,7 @@ public final class OpenShiftUtils {
     /**
      * Invoke openshift's API. Only part behind master url is necessary and the path must start with slash.
      *
-     * @param url  api path
+     * @param url api path
      * @param body body to send as JSON
      * @return response object
      */
@@ -185,10 +189,10 @@ public final class OpenShiftUtils {
         url = TestConfiguration.openShiftUrl() + url;
         log.debug(url);
         Response response = HttpUtils.doPostRequest(
-                url,
-                body,
-                "application/json",
-                Headers.of("Authorization", "Bearer " + OpenShiftUtils.getInstance().getConfiguration().getOauthToken())
+            url,
+            body,
+            "application/json",
+            Headers.of("Authorization", "Bearer " + OpenShiftUtils.getInstance().getConfiguration().getOauthToken())
         );
         log.debug("Response code: " + response.code());
         try {


### PR DESCRIPTION
In this commit:
 - when apicurito ui image is set, override the correct image tag in default image stream
 - new configuration property `apicurito.config.pull.secret` to set pull secret for authentication in a container registry
 - hardcoded image version - when apicurito ui image is set, template will automatically be updated to use provided image with the hardcoded image version